### PR TITLE
Hotfix 3.1.3

### DIFF
--- a/CookedRabbit.Core.Tests/AutoPublisherConsumerTests.cs
+++ b/CookedRabbit.Core.Tests/AutoPublisherConsumerTests.cs
@@ -89,7 +89,7 @@ namespace CookedRabbit.Core.Tests
                 {
                     receiptCount++;
                     if (receipt.IsError)
-                    { error = true;  break; }
+                    { error = true; break; }
                 }
             }
             sw.Stop();

--- a/CookedRabbit.Core.Tests/EncryptionTests.cs
+++ b/CookedRabbit.Core.Tests/EncryptionTests.cs
@@ -1,5 +1,4 @@
 using CookedRabbit.Core.Utils;
-using System;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -31,7 +30,7 @@ namespace CookedRabbit.Core.Tests
         [Fact]
         public async Task EncryptDecryptTest()
         {
-            var data = new byte[] { 0xFF, 0x00, 0xAA, 0xFF, 0x00, 0x00, 0xFF, 0xAA, 0x00, 0xFF,0x00, 0xFF };
+            var data = new byte[] { 0xFF, 0x00, 0xAA, 0xFF, 0x00, 0x00, 0xFF, 0xAA, 0x00, 0xFF, 0x00, 0xFF };
 
             var hashKey = await ArgonHash
                 .GetHashKeyAsync(Passphrase, Salt, 32)

--- a/CookedRabbit.Core.Tests/PublisherTests.cs
+++ b/CookedRabbit.Core.Tests/PublisherTests.cs
@@ -3,7 +3,6 @@ using CookedRabbit.Core.Utils;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;

--- a/CookedRabbit.Core/Bytes.cs
+++ b/CookedRabbit.Core/Bytes.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace CookedRabbit.Core
+{
+    public static class Bytes
+    {
+        public static byte[] Utf8JJsonStartsWith = new byte[] { (byte)'{' };
+        public static byte[] Utf8JsonEndsWith = new byte[] { (byte)'}' };
+
+        public static byte[] Utf8JsonArrayStartsWith = new byte[] { (byte)'[' };
+        public static byte[] Utf8JsonArrayEndsWith = new byte[] { (byte)']' };
+
+        public static bool IsJson(ReadOnlySpan<byte> data)
+        {
+            return
+            // Json
+            (data.StartsWith(Utf8JJsonStartsWith) && data.EndsWith(Utf8JsonEndsWith));
+        }
+
+        public static bool IsJsonArray(ReadOnlySpan<byte> data)
+        {
+            return
+            // JsonArray
+            (data.StartsWith(Utf8JsonArrayStartsWith) && data.StartsWith(Utf8JsonArrayEndsWith));
+        }
+    }
+}

--- a/CookedRabbit.Core/Configs/ConsumerOptions.cs
+++ b/CookedRabbit.Core/Configs/ConsumerOptions.cs
@@ -10,7 +10,7 @@ namespace CookedRabbit.Core
         public string ConsumerName { get; set; }
 
         public string ErrorSuffix { get; set; }
-        public string ErrorQueueName => $"{ConsumerName}.{ErrorSuffix}";
+        public string ErrorQueueName => $"{QueueName}.{ErrorSuffix}";
 
         public string TargetQueueName { get; set; }
         public IDictionary<string, string> TargetQueues { get; set; }

--- a/CookedRabbit.Core/Consumer/Consumer.cs
+++ b/CookedRabbit.Core/Consumer/Consumer.cs
@@ -1,14 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 using CookedRabbit.Core.Pools;
 using CookedRabbit.Core.Utils;
 using CookedRabbit.Core.WorkEngines;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace CookedRabbit.Core
 {
@@ -65,7 +64,7 @@ namespace CookedRabbit.Core
             Config = config;
             ChannelPool = new ChannelPool(Config);
             HashKey = hashKey;
-            
+
             ConsumerSettings = Config.GetConsumerSettings(consumerName);
         }
 

--- a/CookedRabbit.Core/Consumer/LetterConsumer.cs
+++ b/CookedRabbit.Core/Consumer/LetterConsumer.cs
@@ -1,14 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 using CookedRabbit.Core.Pools;
 using CookedRabbit.Core.Utils;
 using CookedRabbit.Core.WorkEngines;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace CookedRabbit.Core
 {

--- a/CookedRabbit.Core/Consumer/MessageConsumer.cs
+++ b/CookedRabbit.Core/Consumer/MessageConsumer.cs
@@ -1,14 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 using CookedRabbit.Core.Pools;
 using CookedRabbit.Core.Utils;
 using CookedRabbit.Core.WorkEngines;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace CookedRabbit.Core
 {

--- a/CookedRabbit.Core/CookedRabbit.Core.csproj
+++ b/CookedRabbit.Core/CookedRabbit.Core.csproj
@@ -10,9 +10,9 @@
     <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>3.1.1.0</AssemblyVersion>
-    <FileVersion>3.1.1.0</FileVersion>
-    <Version>3.1.1</Version>
+    <AssemblyVersion>3.1.3.0</AssemblyVersion>
+    <FileVersion>3.1.3.0</FileVersion>
+    <Version>3.1.3</Version>
     <Authors>HouseofCat.io</Authors>
     <Description>CookedRabbit.Core is a C# RabbitMQ wrapper for NetCore.</Description>
     <Copyright>Copyright © 2018-2020</Copyright>

--- a/CookedRabbit.Core/CookedRabbit.Core.xml
+++ b/CookedRabbit.Core/CookedRabbit.Core.xml
@@ -284,30 +284,6 @@
             </summary>
             <param name="value"></param>
         </member>
-        <member name="M:CookedRabbit.Core.IReceivedData.GetBody">
-            <summary>
-            Use this method to retrieve the internal buffer as byte[].
-            <para>Combine this with header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
-            <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
-            <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
-            <em>Note: Does not decomprypt Letter body.</em>
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:CookedRabbit.Core.IReceivedData.GetTypeFromJsonAsync``1(System.Boolean,System.Boolean,System.Text.Json.JsonSerializerOptions)">
-            <summary>
-            Use this method to attempt to deserialize into your type based on internal buffer.
-            <para>Combine this with AMQP header X-OBJECTTYPE to get message wrapper payloads.</para>
-            <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
-            <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
-            <em>Note: Always decomprypts Letter body regardless of parameters.</em>
-            </summary>
-            <typeparam name="TResult"></typeparam>
-            <param name="decrypt">Is only used for Message/Unknown types.</param>
-            <param name="decompress">Is only used on Message/Unknown types.</param>
-            <param name="jsonSerializerOptions"></param>
-            <returns></returns>
-        </member>
         <member name="M:CookedRabbit.Core.ReceivedData.AckMessage">
             <summary>
             Acknowledges the message server side.
@@ -329,13 +305,37 @@
             <para>Combine this with AMQP header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
             <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
             <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
-            <em>Note: Always decomprypts Letter body regardless of parameters.</em>
+            <em>Note: Does not decomcrypt Letter body.</em>
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:CookedRabbit.Core.ReceivedData.GetBodyAsUtf8String">
+            <summary>
+            Use this method to retrieve the internal buffer as string.
+            <para>Combine this with AMQP header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
+            <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
+            <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
+            <em>Note: Does not decomcrypt Letter body.</em>
             </summary>
             <returns></returns>
         </member>
         <member name="M:CookedRabbit.Core.ReceivedData.GetTypeFromJsonAsync``1(System.Boolean,System.Boolean,System.Text.Json.JsonSerializerOptions)">
             <summary>
             Use this method to attempt to deserialize into your type based on internal buffer.
+            <para>Combine this with AMQP header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
+            <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
+            <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
+            <em>Note: Always decomprypts Letter bodies to get type regardless of parameters.</em>
+            </summary>
+            <typeparam name="TResult"></typeparam>
+            <param name="decrypt"></param>
+            <param name="decompress"></param>
+            <param name="jsonSerializerOptions"></param>
+            <returns></returns>
+        </member>
+        <member name="M:CookedRabbit.Core.ReceivedData.GetTypesFromJsonAsync``1(System.Boolean,System.Boolean,System.Text.Json.JsonSerializerOptions)">
+            <summary>
+            Use this method to attempt to deserialize into your types based on internal buffer.
             <para>Combine this with AMQP header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
             <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
             <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>

--- a/CookedRabbit.Core/Models/Letter.cs
+++ b/CookedRabbit.Core/Models/Letter.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using CookedRabbit.Core.Utils;
+using System;
+using System.Collections.Generic;
 
 namespace CookedRabbit.Core
 {
@@ -75,7 +74,7 @@ namespace CookedRabbit.Core
                 Encrypted = LetterMetadata.Encrypted,
             };
 
-            foreach(var kvp in LetterMetadata.CustomFields)
+            foreach (var kvp in LetterMetadata.CustomFields)
             {
                 metadata.CustomFields.Add(kvp.Key, kvp.Value);
             }

--- a/CookedRabbit.Core/Models/ReceivedData.cs
+++ b/CookedRabbit.Core/Models/ReceivedData.cs
@@ -1,54 +1,38 @@
-using System;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
 using CookedRabbit.Core.Utils;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace CookedRabbit.Core
 {
     public interface IReceivedData
     {
-        IBasicProperties Properties { get; }
         bool Ackable { get; }
-        ulong DeliveryTag { get; }
-        ReadOnlyMemory<byte> Data { get; }
-        Letter Letter { get; }
+        IModel Channel { get; set; }
         string ContentType { get; }
-
-        /// <summary>
-        /// Use this method to retrieve the internal buffer as byte[].
-        /// <para>Combine this with header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
-        /// <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
-        /// <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
-        /// <em>Note: Does not decomprypt Letter body.</em>
-        /// </summary>
-        /// <returns></returns>
-        ReadOnlyMemory<byte> GetBody();
-
-        /// <summary>
-        /// Use this method to attempt to deserialize into your type based on internal buffer.
-        /// <para>Combine this with AMQP header X-OBJECTTYPE to get message wrapper payloads.</para>
-        /// <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
-        /// <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
-        /// <em>Note: Always decomprypts Letter body regardless of parameters.</em>
-        /// </summary>
-        /// <typeparam name="TResult"></typeparam>
-        /// <param name="decrypt">Is only used for Message/Unknown types.</param>
-        /// <param name="decompress">Is only used on Message/Unknown types.</param>
-        /// <param name="jsonSerializerOptions"></param>
-        /// <returns></returns>
-        Task<TResult> GetTypeFromJsonAsync<TResult>(bool decrypt = false, bool decompress = false, JsonSerializerOptions jsonSerializerOptions = null);
+        ReadOnlyMemory<byte> Data { get; }
+        ulong DeliveryTag { get; }
+        Letter Letter { get; }
+        IBasicProperties Properties { get; }
 
         bool AckMessage();
         void Complete();
         Task<bool> Completion();
+        void Dispose();
+        ReadOnlyMemory<byte> GetBody();
+        string GetBodyAsUtf8String();
+        Task<TResult> GetTypeFromJsonAsync<TResult>(bool decrypt = false, bool decompress = false, JsonSerializerOptions jsonSerializerOptions = null);
+        Task<IEnumerable<TResult>> GetTypesFromJsonAsync<TResult>(bool decrypt = false, bool decompress = false, JsonSerializerOptions jsonSerializerOptions = null);
         bool NackMessage(bool requeue);
+        void ReadHeaders();
         bool RejectMessage(bool requeue);
     }
 
-    public class ReceivedData : IReceivedData, IDisposable
+    public class ReceivedData : IDisposable, IReceivedData
     {
         public IBasicProperties Properties { get; }
         public bool Ackable { get; }
@@ -95,7 +79,7 @@ namespace CookedRabbit.Core
 
         public void ReadHeaders()
         {
-            if (Properties.Headers != null && Properties.Headers.ContainsKey(Strings.HeaderForObjectType))
+            if (Properties?.Headers != null && Properties.Headers.ContainsKey(Strings.HeaderForObjectType))
             {
                 ContentType = Encoding.UTF8.GetString((byte[])Properties.Headers[Strings.HeaderForObjectType]);
             }
@@ -171,7 +155,7 @@ namespace CookedRabbit.Core
         /// <para>Combine this with AMQP header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
         /// <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
         /// <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
-        /// <em>Note: Always decomprypts Letter body regardless of parameters.</em>
+        /// <em>Note: Does not decomcrypt Letter body.</em>
         /// </summary>
         /// <returns></returns>
         public ReadOnlyMemory<byte> GetBody()
@@ -189,6 +173,32 @@ namespace CookedRabbit.Core
                 default:
 
                     return Data;
+            }
+        }
+
+        /// <summary>
+        /// Use this method to retrieve the internal buffer as string.
+        /// <para>Combine this with AMQP header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
+        /// <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
+        /// <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
+        /// <em>Note: Does not decomcrypt Letter body.</em>
+        /// </summary>
+        /// <returns></returns>
+        public string GetBodyAsUtf8String()
+        {
+            switch (ContentType)
+            {
+                case Strings.HeaderValueForLetter:
+
+                    if (Letter == null)
+                    { Letter = JsonSerializer.Deserialize<Letter>(Data.Span); }
+
+                    return Encoding.UTF8.GetString(Letter.Body);
+
+                case Strings.HeaderValueForMessage:
+                default:
+
+                    return Encoding.UTF8.GetString(Data.Span);
             }
         }
 
@@ -233,20 +243,90 @@ namespace CookedRabbit.Core
                 case Strings.HeaderValueForMessage:
                 default:
 
-                    byte[] data = null;
-                    if (decrypt && _hashKey.Length > 0)
+                    if (Bytes.IsJson(Data.Span))
                     {
-                        data = AesEncrypt.Decrypt(Data, _hashKey);
+                        byte[] data = null;
+                        if (decrypt && _hashKey.Length > 0)
+                        {
+                            data = AesEncrypt.Decrypt(Data, _hashKey);
+                        }
+
+                        if (decompress)
+                        {
+                            data = await Gzip
+                                .DecompressAsync(data ?? Data)
+                                .ConfigureAwait(false);
+                        }
+
+                        return JsonSerializer.Deserialize<TResult>(data ?? Data.Span, jsonSerializerOptions);
+                    }
+                    else
+                    { return default(TResult); }
+            }
+        }
+
+        /// <summary>
+        /// Use this method to attempt to deserialize into your types based on internal buffer.
+        /// <para>Combine this with AMQP header X-CR-OBJECTTYPE to get message wrapper payloads.</para>
+        /// <para>Header Example: ("X-CR-OBJECTTYPE", "LETTER")</para>
+        /// <para>Header Example: ("X-CR-OBJECTTYPE", "MESSAGE")</para>
+        /// <em>Note: Always decomprypts Letter bodies to get type regardless of parameters.</em>
+        /// </summary>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="decrypt"></param>
+        /// <param name="decompress"></param>
+        /// <param name="jsonSerializerOptions"></param>
+        /// <returns></returns>
+        public async Task<IEnumerable<TResult>> GetTypesFromJsonAsync<TResult>(bool decrypt = false, bool decompress = false, JsonSerializerOptions jsonSerializerOptions = null)
+        {
+            switch (ContentType)
+            {
+                case Strings.HeaderValueForLetter:
+
+                    var types = new List<TResult>();
+                    if (Letter == null)
+                    { Letter = JsonSerializer.Deserialize<Letter>(Data.Span); }
+
+                    if (Letter.LetterMetadata.Encrypted && _hashKey.Length > 0)
+                    {
+                        Letter.Body = AesEncrypt.Decrypt(Letter.Body, _hashKey);
+                        Letter.LetterMetadata.Encrypted = false;
                     }
 
-                    if (decompress)
+                    if (Letter.LetterMetadata.Compressed)
                     {
-                        data = await Gzip
-                            .DecompressAsync(data ?? Data)
+                        Letter.Body = await Gzip
+                            .DecompressAsync(Letter.Body)
                             .ConfigureAwait(false);
+
+                        Letter.LetterMetadata.Compressed = false;
                     }
 
-                    return JsonSerializer.Deserialize<TResult>(data ?? Data.Span, jsonSerializerOptions);
+                    return JsonSerializer.Deserialize<List<TResult>>(Letter.Body.AsSpan(), jsonSerializerOptions);
+
+                case Strings.HeaderValueForMessage:
+                default:
+
+                    if (Bytes.IsJsonArray(Data.Span))
+                    {
+                        byte[] data = null;
+                        if (decrypt && _hashKey.Length > 0)
+                        {
+                            data = AesEncrypt.Decrypt(Data, _hashKey);
+                        }
+
+                        if (decompress)
+                        {
+                            data = await Gzip
+                                .DecompressAsync(data ?? Data)
+                                .ConfigureAwait(false);
+                        }
+
+                        return JsonSerializer.Deserialize<List<TResult>>(data ?? Data.Span, jsonSerializerOptions);
+                    }
+                    else
+                    { return default(List<TResult>); }
+
             }
         }
 

--- a/CookedRabbit.Core/Models/ReceivedLetter.cs
+++ b/CookedRabbit.Core/Models/ReceivedLetter.cs
@@ -1,7 +1,6 @@
-using System.Text.Json;
-using System.Threading.Tasks;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
+using System.Text.Json;
 
 namespace CookedRabbit.Core
 {

--- a/CookedRabbit.Core/Models/ReceivedMessage.cs
+++ b/CookedRabbit.Core/Models/ReceivedMessage.cs
@@ -1,9 +1,8 @@
-using System;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
-using RabbitMQ.Client;
-using RabbitMQ.Client.Events;
 
 namespace CookedRabbit.Core
 {

--- a/CookedRabbit.Core/Pools/ChannelHost.cs
+++ b/CookedRabbit.Core/Pools/ChannelHost.cs
@@ -1,6 +1,6 @@
+using RabbitMQ.Client;
 using System;
 using System.Threading.Tasks;
-using RabbitMQ.Client;
 
 namespace CookedRabbit.Core.Pools
 {

--- a/CookedRabbit.Core/Pools/ChannelPool.cs
+++ b/CookedRabbit.Core/Pools/ChannelPool.cs
@@ -1,10 +1,10 @@
+using CookedRabbit.Core.Utils;
 using System;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using CookedRabbit.Core.Utils;
 
 namespace CookedRabbit.Core.Pools
 {

--- a/CookedRabbit.Core/Pools/ConnectionHost.cs
+++ b/CookedRabbit.Core/Pools/ConnectionHost.cs
@@ -1,6 +1,6 @@
+using RabbitMQ.Client;
 using System.Threading;
 using System.Threading.Tasks;
-using RabbitMQ.Client;
 
 namespace CookedRabbit.Core.Pools
 {

--- a/CookedRabbit.Core/Pools/ConnectionPool.cs
+++ b/CookedRabbit.Core/Pools/ConnectionPool.cs
@@ -1,10 +1,10 @@
+using CookedRabbit.Core.Utils;
+using RabbitMQ.Client;
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using CookedRabbit.Core.Utils;
-using RabbitMQ.Client;
 
 namespace CookedRabbit.Core.Pools
 {

--- a/CookedRabbit.Core/Publisher/AutoPublisher.cs
+++ b/CookedRabbit.Core/Publisher/AutoPublisher.cs
@@ -1,9 +1,9 @@
+using CookedRabbit.Core.Pools;
+using CookedRabbit.Core.Utils;
 using System;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using CookedRabbit.Core.Pools;
-using CookedRabbit.Core.Utils;
 
 namespace CookedRabbit.Core
 {

--- a/CookedRabbit.Core/Publisher/Publisher.cs
+++ b/CookedRabbit.Core/Publisher/Publisher.cs
@@ -1,12 +1,12 @@
+using CookedRabbit.Core.Pools;
+using CookedRabbit.Core.Utils;
+using RabbitMQ.Client;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using CookedRabbit.Core.Pools;
-using CookedRabbit.Core.Utils;
-using RabbitMQ.Client;
 
 namespace CookedRabbit.Core
 {

--- a/CookedRabbit.Core/Service/MaintenanceService.cs
+++ b/CookedRabbit.Core/Service/MaintenanceService.cs
@@ -1,7 +1,7 @@
-using System.Threading.Tasks;
 using CookedRabbit.Core.Pools;
 using CookedRabbit.Core.Utils;
 using RabbitMQ.Client;
+using System.Threading.Tasks;
 
 namespace CookedRabbit.Core.Service
 {

--- a/CookedRabbit.Core/Service/RabbitService.cs
+++ b/CookedRabbit.Core/Service/RabbitService.cs
@@ -1,12 +1,12 @@
+using CookedRabbit.Core.Pools;
+using CookedRabbit.Core.Utils;
+using RabbitMQ.Client;
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using CookedRabbit.Core.Pools;
-using CookedRabbit.Core.Utils;
-using RabbitMQ.Client;
 
 namespace CookedRabbit.Core.Service
 {

--- a/CookedRabbit.Core/Topology/Topologer.cs
+++ b/CookedRabbit.Core/Topology/Topologer.cs
@@ -1,9 +1,9 @@
+using CookedRabbit.Core.Pools;
+using CookedRabbit.Core.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using CookedRabbit.Core.Pools;
-using CookedRabbit.Core.Utils;
 
 namespace CookedRabbit.Core
 {

--- a/CookedRabbit.Core/Utils/Encryption/AesEncrypt.cs
+++ b/CookedRabbit.Core/Utils/Encryption/AesEncrypt.cs
@@ -1,9 +1,9 @@
-using System;
-using System.IO;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Engines;
 using Org.BouncyCastle.Crypto.Modes;
 using Org.BouncyCastle.Crypto.Parameters;
+using System;
+using System.IO;
 
 namespace CookedRabbit.Core.Utils
 {

--- a/CookedRabbit.Core/Utils/Encryption/ArgonHash.cs
+++ b/CookedRabbit.Core/Utils/Encryption/ArgonHash.cs
@@ -1,6 +1,6 @@
+using Konscious.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using Konscious.Security.Cryptography;
 
 namespace CookedRabbit.Core.Utils
 {


### PR DESCRIPTION
- Headers handled as null.
- Properties handled as null.
- ReceiveData non-JSON handling when trying to deserialize without Try/Catch
- ReceiveData additional features to aid in data reading.
- Enhanced the PipelineClient to really demonstrate some error handling.
- Fixed the ErrorQueueName on Consumers, it is now your QueueName.ErrorSuffix, not ConsumerName.ErrorSuffix.