### PR TITLE
Service name missing on the connection.

### DIFF
--- a/CookedRabbit.Core.Tests/Config.json
+++ b/CookedRabbit.Core.Tests/Config.json
@@ -18,7 +18,7 @@
     }
   },
   "PoolSettings": {
-    "ConnectionPoolName": "PipelineClient",
+    "ServiceName": "PipelineClient",
     "MaxConnections": 5,
     "MaxChannels": 25,
     "SleepOnErrorInterval": 1000

--- a/CookedRabbit.Core.Tests/TestConfig.json
+++ b/CookedRabbit.Core.Tests/TestConfig.json
@@ -1,81 +1,81 @@
 {
-    "FactorySettings": {
-        "Uri": "amqp://guest:guest@localhost:5672/",
-        "MaxChannelsPerConnection": 100,
-        "HeartbeatInterval": 6,
-        "AutoRecovery": true,
-        "TopologyRecovery": true,
-        "NetRecoveryTimeout": 10,
-        "ContinuationTimeout": 10,
-        "EnableDispatchConsumersAsync": false,
-        "UseBackgroundThreadsForIO": true,
-        "SslSettings": {
-            "EnableSsl": false,
-            "CertServerName": "",
-            "LocalCertPath": "",
-            "LocalCertPassword": "",
-            "ProtocolVersions": 3072
-        }
-    },
-    "PoolSettings": {
-        "ConnectionPoolName": "TestServiceName",
-        "MaxConnections": 5,
-        "MaxChannels": 25,
-        "SleepOnErrorInterval": 1000
-    },
-    "PublisherSettings": {
-        "LetterQueueBufferSize": 10000,
-        "PriorityLetterQueueBufferSize": 100,
-        "BehaviorWhenFull": 0,
-        "AutoPublisherSleepInterval": 1000,
-        "CreatePublishReceipts":  true
-    },
-    "LetterConsumerSettings": {
-        "TestLetterConsumer": {
-            "ConsumerName": "TestLetterConsumer",
-            "QueueName": "TestConsumerQueue",
-            "NoLocal": false,
-            "Exclusive": false,
-            "QosPrefetchCount": 5,
-            "RabbitMessageBufferSize": 100,
-            "BehaviorWhenFull": 0,
-            "Enabled": true,
-            "SleepOnIdleInterval": 1000
-        },
-        "TestAutoPublisherConsumerName": {
-            "ConsumerName": "TestAutoPublisherConsumerName",
-            "QueueName": "TestAutoPublisherConsumerQueue",
-            "NoLocal": false,
-            "Exclusive": false,
-            "QosPrefetchCount": 5,
-            "RabbitMessageBufferSize": 100,
-            "BehaviorWhenFull": 0,
-            "Enabled": true,
-            "SleepOnIdleInterval": 1000
-        }
-    },
-    "MessageConsumerSettings": {
-        "TestMessageConsumer": {
-            "ConsumerName": "TestMessageConsumer",
-            "QueueName": "TestConsumerQueue",
-            "NoLocal": false,
-            "Exclusive": false,
-            "QosPrefetchCount": 10,
-            "RabbitMessageBufferSize": 1000,
-            "BehaviorWhenFull": 0,
-            "Enabled": true,
-            "SleepOnIdleInterval": 1000
-        },
-        "TestAutoPublisherConsumerName": {
-            "ConsumerName": "TestAutoPublisherConsumerName",
-            "QueueName": "TestAutoPublisherConsumerQueue",
-            "NoLocal": false,
-            "Exclusive": false,
-            "QosPrefetchCount": 5,
-            "RabbitMessageBufferSize": 100,
-            "BehaviorWhenFull": 0,
-            "Enabled": true,
-            "SleepOnIdleInterval": 1000
-        }
+  "FactorySettings": {
+    "Uri": "amqp://guest:guest@localhost:5672/",
+    "MaxChannelsPerConnection": 100,
+    "HeartbeatInterval": 6,
+    "AutoRecovery": true,
+    "TopologyRecovery": true,
+    "NetRecoveryTimeout": 10,
+    "ContinuationTimeout": 10,
+    "EnableDispatchConsumersAsync": false,
+    "UseBackgroundThreadsForIO": true,
+    "SslSettings": {
+      "EnableSsl": false,
+      "CertServerName": "",
+      "LocalCertPath": "",
+      "LocalCertPassword": "",
+      "ProtocolVersions": 3072
     }
+  },
+  "PoolSettings": {
+    "ServiceName": "TestServiceName",
+    "MaxConnections": 5,
+    "MaxChannels": 25,
+    "SleepOnErrorInterval": 1000
+  },
+  "PublisherSettings": {
+    "LetterQueueBufferSize": 10000,
+    "PriorityLetterQueueBufferSize": 100,
+    "BehaviorWhenFull": 0,
+    "AutoPublisherSleepInterval": 1000,
+    "CreatePublishReceipts": true
+  },
+  "LetterConsumerSettings": {
+    "TestLetterConsumer": {
+      "ConsumerName": "TestLetterConsumer",
+      "QueueName": "TestConsumerQueue",
+      "NoLocal": false,
+      "Exclusive": false,
+      "QosPrefetchCount": 5,
+      "RabbitMessageBufferSize": 100,
+      "BehaviorWhenFull": 0,
+      "Enabled": true,
+      "SleepOnIdleInterval": 1000
+    },
+    "TestAutoPublisherConsumerName": {
+      "ConsumerName": "TestAutoPublisherConsumerName",
+      "QueueName": "TestAutoPublisherConsumerQueue",
+      "NoLocal": false,
+      "Exclusive": false,
+      "QosPrefetchCount": 5,
+      "RabbitMessageBufferSize": 100,
+      "BehaviorWhenFull": 0,
+      "Enabled": true,
+      "SleepOnIdleInterval": 1000
+    }
+  },
+  "MessageConsumerSettings": {
+    "TestMessageConsumer": {
+      "ConsumerName": "TestMessageConsumer",
+      "QueueName": "TestConsumerQueue",
+      "NoLocal": false,
+      "Exclusive": false,
+      "QosPrefetchCount": 10,
+      "RabbitMessageBufferSize": 1000,
+      "BehaviorWhenFull": 0,
+      "Enabled": true,
+      "SleepOnIdleInterval": 1000
+    },
+    "TestAutoPublisherConsumerName": {
+      "ConsumerName": "TestAutoPublisherConsumerName",
+      "QueueName": "TestAutoPublisherConsumerQueue",
+      "NoLocal": false,
+      "Exclusive": false,
+      "QosPrefetchCount": 5,
+      "RabbitMessageBufferSize": 100,
+      "BehaviorWhenFull": 0,
+      "Enabled": true,
+      "SleepOnIdleInterval": 1000
+    }
+  }
 }

--- a/CookedRabbit.Core/Configs/PoolOptions.cs
+++ b/CookedRabbit.Core/Configs/PoolOptions.cs
@@ -5,7 +5,7 @@ namespace CookedRabbit.Core
         /// <summary>
         /// Value to configure the ConnectionPool prefix for display names on RabbitMQ server.
         /// </summary>
-        public string ConnectionPoolName { get; set; } = string.Empty;
+        public string ServiceName { get; set; } = string.Empty;
 
         /// <summary>
         /// Number of connections to be created in the ConnectionPool. Used in round-robin to create channels.

--- a/Examples/PipelineClient/Config.json
+++ b/Examples/PipelineClient/Config.json
@@ -18,7 +18,7 @@
     }
   },
   "PoolSettings": {
-    "ConnectionPoolName": "PipelineClient",
+    "ServiceName": "PipelineClient",
     "MaxConnections": 5,
     "MaxChannels": 25,
     "SleepOnErrorInterval": 1000

--- a/Examples/StressTestClient/Config.json
+++ b/Examples/StressTestClient/Config.json
@@ -18,7 +18,7 @@
     }
   },
   "PoolSettings": {
-    "ConnectionPoolName": "StressTestConsole",
+    "ServiceName": "StressTestConsole",
     "MaxConnections": 10,
     "MaxChannels": 50,
     "SleepOnErrorInterval": 1000


### PR DESCRIPTION
 * Fixing the missing service name when making connections.
 * Renamed property under PoolOptions to ServiceName for clarity.

Default value when not provided: `"CookedRabbit:{i}"` where `i` is the connection number in the pool.